### PR TITLE
解决长按抖动卡死的bug 并 整理代码格式

### DIFF
--- a/examples/example_callback.c
+++ b/examples/example_callback.c
@@ -5,54 +5,54 @@ struct Button btn2;
 
 uint8_t read_button1_GPIO()
 {
-	return HAL_GPIO_ReadPin(B1_GPIO_Port, B1_Pin);
+    return HAL_GPIO_ReadPin(B1_GPIO_Port, B1_Pin);
 }
 
 uint8_t read_button2_GPIO()
 {
-	return HAL_GPIO_ReadPin(B2_GPIO_Port, B2_Pin);
+    return HAL_GPIO_ReadPin(B2_GPIO_Port, B2_Pin);
 }
 
 int main()
 {
-	button_init(&btn1, read_button1_GPIO, 0);
-	button_init(&btn2, read_button2_GPIO, 0);
+    button_init(&btn1, read_button1_GPIO, 0);
+    button_init(&btn2, read_button2_GPIO, 0);
 
-	button_attach(&btn1, PRESS_DOWN,       BTN1_PRESS_DOWN_Handler);
-	button_attach(&btn1, PRESS_UP,         BTN1_PRESS_UP_Handler);
-	button_attach(&btn1, PRESS_REPEAT,     BTN1_PRESS_REPEAT_Handler);
-	button_attach(&btn1, SINGLE_CLICK,     BTN1_SINGLE_Click_Handler);
-	button_attach(&btn1, DOUBLE_CLICK,     BTN1_DOUBLE_Click_Handler);
-	button_attach(&btn1, LONG_PRESS_START, BTN1_LONG_PRESS_START_Handler);
-	button_attach(&btn1, LONG_PRESS_HOLD,  BTN1_LONG_PRESS_HOLD_Handler);
+    button_attach(&btn1, PRESS_DOWN,       BTN1_PRESS_DOWN_Handler);
+    button_attach(&btn1, PRESS_UP,         BTN1_PRESS_UP_Handler);
+    button_attach(&btn1, PRESS_REPEAT,     BTN1_PRESS_REPEAT_Handler);
+    button_attach(&btn1, SINGLE_CLICK,     BTN1_SINGLE_Click_Handler);
+    button_attach(&btn1, DOUBLE_CLICK,     BTN1_DOUBLE_Click_Handler);
+    button_attach(&btn1, LONG_PRESS_START, BTN1_LONG_PRESS_START_Handler);
+    button_attach(&btn1, LONG_PRESS_HOLD,  BTN1_LONG_PRESS_HOLD_Handler);
 
-	button_attach(&btn2, PRESS_DOWN,       BTN2_PRESS_DOWN_Handler);
-	button_attach(&btn2, PRESS_UP,         BTN2_PRESS_UP_Handler);
-	button_attach(&btn2, PRESS_REPEAT,     BTN2_PRESS_REPEAT_Handler);
-	button_attach(&btn2, SINGLE_CLICK,     BTN2_SINGLE_Click_Handler);
-	button_attach(&btn2, DOUBLE_CLICK,     BTN2_DOUBLE_Click_Handler);
-	button_attach(&btn2, LONG_PRESS_START, BTN2_LONG_PRESS_START_Handler);
-	button_attach(&btn2, LONG_PRESS_HOLD,  BTN2_LONG_PRESS_HOLD_Handler);
+    button_attach(&btn2, PRESS_DOWN,       BTN2_PRESS_DOWN_Handler);
+    button_attach(&btn2, PRESS_UP,         BTN2_PRESS_UP_Handler);
+    button_attach(&btn2, PRESS_REPEAT,     BTN2_PRESS_REPEAT_Handler);
+    button_attach(&btn2, SINGLE_CLICK,     BTN2_SINGLE_Click_Handler);
+    button_attach(&btn2, DOUBLE_CLICK,     BTN2_DOUBLE_Click_Handler);
+    button_attach(&btn2, LONG_PRESS_START, BTN2_LONG_PRESS_START_Handler);
+    button_attach(&btn2, LONG_PRESS_HOLD,  BTN2_LONG_PRESS_HOLD_Handler);
 
-	button_start(&btn1);
-	button_start(&btn2);
+    button_start(&btn1);
+    button_start(&btn2);
 
-	//make the timer invoking the button_ticks() interval 5ms.
-	//This function is implemented by yourself.
-	__timer_start(button_ticks, 0, 5);
+    //make the timer invoking the button_ticks() interval 5ms.
+    //This function is implemented by yourself.
+    __timer_start(button_ticks, 0, 5);
 
-	while(1)
-	{}
+    while(1)
+    {}
 }
 
 void BTN1_PRESS_DOWN_Handler(void* btn)
 {
-	//do something...
+    //do something...
 }
 
 void BTN1_PRESS_UP_Handler(void* btn)
 {
-	//do something...
+    //do something...
 }
 
 ...

--- a/examples/example_poll.c
+++ b/examples/example_poll.c
@@ -2,36 +2,36 @@
 
 struct Button btn1;
 
-uint8_t read_button1_GPIO() 
+uint8_t read_button1_GPIO()
 {
-	return HAL_GPIO_ReadPin(B1_GPIO_Port, B1_Pin);
+    return HAL_GPIO_ReadPin(B1_GPIO_Port, B1_Pin);
 }
 
 
 int main()
 {
-	static uint8_t btn1_event_val;
-	
-	button_init(&btn1, read_button1_GPIO, 0);
-	button_start(&btn1);
-	
-	//make the timer invoking the button_ticks() interval 5ms.
-	//This function is implemented by yourself.
-	__timer_start(button_ticks, 0, 5); 
-	
-	while(1) 
-	{
-		if(btn1_event_val != get_button_event(&btn1)) {
-			btn1_event_val = get_button_event(&btn1);
-			
-			if(btn1_event_val == PRESS_DOWN) {
-				//do something
-			} else if(btn1_event_val == PRESS_UP) {
-				//do something
-			} else if(btn1_event_val == LONG_PRESS_HOLD) {
-				//do something
-			}
-		}
-	}
+    static uint8_t btn1_event_val;
+
+    button_init(&btn1, read_button1_GPIO, 0);
+    button_start(&btn1);
+
+    //make the timer invoking the button_ticks() interval 5ms.
+    //This function is implemented by yourself.
+    __timer_start(button_ticks, 0, 5);
+
+    while(1)
+    {
+        if(btn1_event_val != get_button_event(&btn1)) {
+            btn1_event_val = get_button_event(&btn1);
+
+            if(btn1_event_val == PRESS_DOWN) {
+                //do something
+            } else if(btn1_event_val == PRESS_UP) {
+                //do something
+            } else if(btn1_event_val == LONG_PRESS_HOLD) {
+                //do something
+            }
+        }
+    }
 }
 

--- a/multi_button.c
+++ b/multi_button.c
@@ -178,7 +178,6 @@ void button_stop(struct Button* handle)
         struct Button* entry = *curr;
         if (entry == handle) {
             *curr = entry->next;
-//          free(entry);
         } else
             curr = &entry->next;
     }

--- a/multi_button.c
+++ b/multi_button.c
@@ -129,6 +129,8 @@ void button_handler(struct Button* handle)
 			} else {
 				handle->state = 0;
 			}
+		} else if(handle->ticks > LONG_TICKS) {
+			handle->state = 5;
 		}
 		break;
 

--- a/multi_button.h
+++ b/multi_button.h
@@ -10,8 +10,8 @@
 #include "string.h"
 
 //According to your need to modify the constants.
-#define TICKS_INTERVAL    5	//ms
-#define DEBOUNCE_TICKS    3	//MAX 8
+#define TICKS_INTERVAL    5 //ms
+#define DEBOUNCE_TICKS    3 //MAX 8
 #define SHORT_TICKS       (300 /TICKS_INTERVAL)
 #define LONG_TICKS        (1000 /TICKS_INTERVAL)
 
@@ -19,28 +19,28 @@
 typedef void (*BtnCallback)(void*);
 
 typedef enum {
-	PRESS_DOWN = 0,
-	PRESS_UP,
-	PRESS_REPEAT,
-	SINGLE_CLICK,
-	DOUBLE_CLICK,
-	LONG_PRESS_START,
-	LONG_PRESS_HOLD,
-	number_of_event,
-	NONE_PRESS
+    PRESS_DOWN = 0,
+    PRESS_UP,
+    PRESS_REPEAT,
+    SINGLE_CLICK,
+    DOUBLE_CLICK,
+    LONG_PRESS_START,
+    LONG_PRESS_HOLD,
+    number_of_event,
+    NONE_PRESS
 }PressEvent;
 
 typedef struct Button {
-	uint16_t ticks;
-	uint8_t  repeat : 4;
-	uint8_t  event : 4;
-	uint8_t  state : 3;
-	uint8_t  debounce_cnt : 3;
-	uint8_t  active_level : 1;
-	uint8_t  button_level : 1;
-	uint8_t  (*hal_button_Level)(void);
-	BtnCallback  cb[number_of_event];
-	struct Button* next;
+    uint16_t ticks;
+    uint8_t  repeat : 4;
+    uint8_t  event : 4;
+    uint8_t  state : 3;
+    uint8_t  debounce_cnt : 3;
+    uint8_t  active_level : 1;
+    uint8_t  button_level : 1;
+    uint8_t  (*hal_button_Level)(void);
+    BtnCallback  cb[number_of_event];
+    struct Button* next;
 }Button;
 
 #ifdef __cplusplus


### PR DESCRIPTION
1. 解决长按抖动卡死的bug
https://github.com/0x1abin/MultiButton/issues/15
https://github.com/liu2guang/MultiButton/issues/3

2.整理代码格式
用空格代替tab
删除每行末尾没有用的空格

合并后 可以关闭 issue #15 #13