### PR TITLE
multi_button.c: add the default keyword for the switch case

### DIFF
--- a/multi_button.c
+++ b/multi_button.c
@@ -148,6 +148,9 @@ void button_handler(struct Button* handle)
 			handle->state = 0; //reset
 		}
 		break;
+    default:
+        handle->state = 0; //reset
+        break;
 	}
 }
 
@@ -199,4 +202,3 @@ void button_ticks()
 		button_handler(target);
 	}
 }
-


### PR DESCRIPTION
multi_button.c: add the default keyword for the switch case

Signed-off-by: Junbo Zheng <3273070@qq.com>