### PR TITLE
[fix]修复短按->长按按键误触发按下事件

### DIFF
--- a/multi_button.c
+++ b/multi_button.c
@@ -132,7 +132,7 @@ void button_handler(struct Button* handle)
 				handle->state = 0;
 			}
 		}else if(handle->ticks > SHORT_TICKS){ // long press up
-			handle->state = 0;
+			handle->state = 1;
 		}
 		break;
 


### PR DESCRIPTION
问题描述：

1. 当按键按以下顺序按下时： 短按 -> 长按，`handle->state` 的值 `0 -> 1 -> 2 -> 0 -> 1`，会多触发一次 `EVENT_CB(PRESS_DOWN);` 事件回调，实际不需要，`handle->state` 的正确状态应该为 `0 -> 1 -> 2 -> 1`