### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ button_init(&btn1, read_button_gpio, 0, 1);
 
 ### 5. 注册事件回调
 ```c
-void btn1_single_click_handler(void* btn)
+void btn1_single_click_handler(Button* btn)
 {
     printf("Button 1: Single Click\n");
 }


### PR DESCRIPTION
更新 ”5.注册事件回调“ 的参数类型：void* --> Button*
解决编译器提示问题：argument of type "void (*)(void *)" is incompatible with parameter of type "BtnCallback"
BtnCallback 的定义是 typedef void (*BtnCallback)(Button* btn_handle);，参数类型是 Button* 而不是 void*