### PR TITLE
[fix]修复双击时注册BTN_PRESS_REPEAT回调时，误触发BTN_PRESS_DOWN事件

### DIFF
--- a/multi_button.c
+++ b/multi_button.c
@@ -183,6 +183,7 @@ static void button_handler(Button* handle)
 			if (handle->repeat < PRESS_REPEAT_MAX_NUM) {
 				handle->repeat++;
 			}
+            handle->event = (uint8_t)BTN_PRESS_REPEAT;
 			EVENT_CB(BTN_PRESS_REPEAT);
 			handle->ticks = 0;
 			handle->state = BTN_STATE_REPEAT;


### PR DESCRIPTION
当注册BTN_PRESS_REPEAT事件回调函数时，在如下状态机时实际触发的是BTN_PRESS_DOWN
<img width="621" height="483" alt="image" src="https://github.com/user-attachments/assets/ed48866a-e8b1-4a79-92ca-163ef47a57e5" />
