### PR TITLE
[Feature] add long press callback interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ void timer_5ms_isr(void)
 ## State Machine
 
 ```
-                          +-- long hold -->  [LONG_HOLD]
-                          |                      |
-[IDLE] -- press --> [PRESS]                   release
-   ^                  |                          |
-   |               release                       |
-   |                  v                          |
-   |             [RELEASE] <---------------------+
+   +------------- release --------- [LONG_HOLD]
+   v                                     ^             
+[IDLE] -- press --> [PRESS] --long hold--+        
+   ^                  |                          
+   |               release                       
+   |                  v                          
+   |             [RELEASE]
    |             |       ^
    |      timeout|       | quick press
    |             |       |

--- a/README_CN.md
+++ b/README_CN.md
@@ -265,13 +265,13 @@ void on_long_hold(Button* btn, void* user_data)
 ## 状态机说明
 
 ```
-                          +-- 长按 -->  [LONG_HOLD]
-                          |                  |
-[IDLE] -- 按下 --> [PRESS]                 抬起
-   ^                  |                      |
-   |               抬起                      |
-   |                  v                      |
-   |             [RELEASE] <-----------------+
+   +------------- 抬起 --------- [LONG_HOLD]
+   v                                     ^             
+[IDLE] -- 按下 --> [PRESS] ----- 长按 ----+                                 
+   ^                  |                      
+   |               抬起                      
+   |                  v                      
+   |             [RELEASE]
    |             |       ^
    |          超时|       | 快速按下
    |             |       |

--- a/multi_button.c
+++ b/multi_button.c
@@ -177,6 +177,9 @@ static void button_handler(Button* handle)
 			handle->event = (uint8_t)BTN_LONG_PRESS_START;
 			EVENT_CB(BTN_LONG_PRESS_START);
 			handle->state = BTN_STATE_LONG_HOLD;
+			#if LONG_CALLBACK_TICKS > 1 // if LONG_CALLBACK_TICKS is 1, we will call BTN_LONG_PRESS_HOLD immediately in the next tick, no need to reset ticks here
+			  handle->ticks = 0;      // reset for long-press hold timing
+			#endif
 		}
 		break;
 
@@ -228,6 +231,13 @@ static void button_handler(Button* handle)
 		if (handle->button_level == handle->active_level) {
 			// Continue holding
 			handle->event = (uint8_t)BTN_LONG_PRESS_HOLD;
+			#if LONG_CALLBACK_TICKS > 1
+			  if (handle->ticks >= LONG_CALLBACK_TICKS) {
+				handle->ticks = 0;  // reset for next long-press hold callback
+			  } else {
+				break;  // not yet time for next callback
+			  }
+			#endif
 			EVENT_CB(BTN_LONG_PRESS_HOLD);
 		} else {
 			// Released from long press

--- a/multi_button.c
+++ b/multi_button.c
@@ -232,11 +232,7 @@ static void button_handler(Button* handle)
 			// Continue holding
 			handle->event = (uint8_t)BTN_LONG_PRESS_HOLD;
 			#if LONG_CALLBACK_TICKS > 1
-			  if (handle->ticks >= LONG_CALLBACK_TICKS) {
-				handle->ticks = 0;  // reset for next long-press hold callback
-			  } else {
-				break;  // not yet time for next callback
-			  }
+			  if(handle->ticks % LONG_CALLBACK_TICKS != 0) break; // only call callback at defined intervals
 			#endif
 			EVENT_CB(BTN_LONG_PRESS_HOLD);
 		} else {

--- a/multi_button.h
+++ b/multi_button.h
@@ -26,6 +26,10 @@
 #if DEBOUNCE_TICKS > 7
   #error "DEBOUNCE_TICKS exceeds 3-bit field maximum (7)"
 #endif
+// Compile-time check: avoid div-0 problem
+#if LONG_CALLBACK_TICKS < 1
+  #error "LONG_CALLBACK_TICKS must be at least 1"
+#endif
 
 
 // Forward declaration

--- a/multi_button.h
+++ b/multi_button.h
@@ -19,12 +19,14 @@
 #define DEBOUNCE_TICKS          3    // MAX 7 (0 ~ 7) - debounce filter depth
 #define SHORT_TICKS             (300 / TICKS_INTERVAL)   // short press threshold
 #define LONG_TICKS              (1000 / TICKS_INTERVAL)  // long press threshold
+#define LONG_CALLBACK_TICKS		5	 // minimum TICKS interval between two BTN_LONG_PRESS_HOLD event callback. LONG_CALLBACK_TICKS * TICKS_INTERVAL = minimum interval in ms.
 #define PRESS_REPEAT_MAX_NUM    15   // maximum repeat counter value
 
 // Compile-time check: debounce_cnt is a 3-bit field, max value is 7
 #if DEBOUNCE_TICKS > 7
   #error "DEBOUNCE_TICKS exceeds 3-bit field maximum (7)"
 #endif
+
 
 // Forward declaration
 typedef struct _Button Button;

--- a/tests/test_button.c
+++ b/tests/test_button.c
@@ -366,7 +366,7 @@ static int test_ticks_saturation(void)
 
     /* Press and hold the button */
     mock_gpio_value = 1;
-    tick_n(DEBOUNCE_TICKS + 5);
+    tick_n(DEBOUNCE_TICKS + 5 + LONG_TICKS);
 
     /* Manually set ticks near UINT16_MAX to test saturation */
     test_btn.ticks = UINT16_MAX - 2;


### PR DESCRIPTION
## Summary

1. Adds macro LONG_CALLBACK_TICKS, provide an interval between two callback function BTN_LONG_PRESS_HOLD called.
2. Updates `test case 12` to cover and verify this new feature.
3. Fixes an inaccuracy state machine diagram in both README.md.

## Changes

### Feature
- Long press state contains `idle -> press -> long-press-hold -> idle`, so reset of `handle->tick` won't interfere with other state.
- Uses conditional compilation macro to provide optional use

### Tests
- make sure state machine has entered `BTN_STATE_LONG_HOLD` before manually setting ticks near UINT16_MAX

## Testing

- [x] `make test` passes
- [x] `make all` compiles without warnings
- [x] Tested on hardware (if applicable): implemented on STM32F103C8T6, using long press to change lamp brightness continuously. Use this interval to match button tick and lamp tick.
- [x] Flash usage increase by 40 Byte after setting LONG_CALLBACK_TICKS larger than 1

*P.S. This is my first PR. I'm very excited to contribute! Any feedback or suggestions for improvement are greatly appreciated.*